### PR TITLE
Bump and pin to NixOS 24.05 nixpkgs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: dprint/check@2f1cf31537886c3bfb05591c031f7744e48ba8a1 # v2.2
         with:
-          dprint-version: '0.46.1' # selfup { "extract": "\\d[^']+", "replacer": ["dprint", "--version"], "nth": 2 }
+          dprint-version: '0.45.1' # selfup { "extract": "\\d[^']+", "replacer": ["dprint", "--version"], "nth": 2 }
 
   typos:
     timeout-minutes: 15

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "edge-nixpkgs": {
-      "locked": {
-        "lastModified": 1717974879,
-        "narHash": "sha256-GTO3C88+5DX171F/gVS3Qga/hOs/eRMxPFpiHq2t+D8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c7b821ba2e1e635ba5a76d299af62821cbcb09f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,23 +20,22 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717880976,
-        "narHash": "sha256-BRvSCsKtDUr83NEtbGfHLUOdDK0Cgbezj2PtcHnz+sQ=",
+        "lastModified": 1717952948,
+        "narHash": "sha256-mJi4/gjiwQlSaxjA6AusXBN/6rQRaPCycR7bd8fydnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4913a7c3d8b8d00cb9476a6bd730ff57777f740c",
+        "rev": "2819fffa7fa42156680f0d282c60d81e8fb185b7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "edge-nixpkgs": "edge-nixpkgs",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   inputs = {
     # How to update the revision
     #   - `nix flake update --commit-lock-file` # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake-update.html
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-    edge-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -11,17 +10,15 @@
     {
       self,
       nixpkgs,
-      edge-nixpkgs,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        edge-pkgs = edge-nixpkgs.legacyPackages.${system};
       in
       {
-        formatter = edge-pkgs.nixfmt-rfc-style;
+        formatter = pkgs.nixfmt-rfc-style;
         devShells.default =
           with pkgs;
           mkShell {
@@ -30,13 +27,13 @@
               # https://github.com/NixOS/nix/issues/730#issuecomment-162323824
               bashInteractive
               nil
-              edge-pkgs.nixfmt-rfc-style
+              nixfmt-rfc-style
 
-              edge-pkgs.nodejs_20
-              edge-pkgs.yamlfmt
-              edge-pkgs.deno
-              edge-pkgs.dprint
-              edge-pkgs.typos
+              nodejs_20
+              yamlfmt
+              deno
+              dprint
+              typos
             ];
           };
       }


### PR DESCRIPTION
- **Bump and pin to NixOS 24.05**
- **`git ls-files '.github/workflows/*.yml' | xargs nix run github:kachick/selfup/v1.1.2 -- run`**
